### PR TITLE
Allow editing the markers through the map

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "dependencies": {
     "@monsonjeremy/react-leaflet": "3.2.2",
     "@monsonjeremy/react-leaflet-core": "1.1.1",
-    "leaflet": "^1.7.1"
+    "leaflet": "^1.7.1",
+    "leaflet-editable": "1.2.0",
+    "react-leaflet-editable": "0.2.2"
   },
   "peerDependencies": {
     "@plone/volto": ">=12.1.2"

--- a/src/Blocks/LeafletMap/Edit.jsx
+++ b/src/Blocks/LeafletMap/Edit.jsx
@@ -49,7 +49,7 @@ const LeafletBlockEdit = (props) => {
           onChangeField={handleChange}
         />
       </SidebarPortal>
-      <Map data={data} />
+      <Map data={data} editMode={true} onChangeField={handleChange} />
     </>
   );
 };

--- a/src/Blocks/LeafletMap/EditableMap.jsx
+++ b/src/Blocks/LeafletMap/EditableMap.jsx
@@ -1,0 +1,102 @@
+import {
+  MapContainer,
+  Marker as LeafletMarker,
+  Popup,
+  TileLayer,
+  useMap,
+  useMapEvents,
+} from '@monsonjeremy/react-leaflet';
+import config from '@plone/volto/registry';
+import 'leaflet-editable';
+import { useRef, useState } from 'react';
+import ReactLeafletEditable from 'react-leaflet-editable';
+import '../../style/leaflet.less';
+import L from 'leaflet';
+import { v4 as uuid } from 'uuid';
+import RenderMarkers from './RenderMarkers';
+import { Button } from 'semantic-ui-react';
+
+const EditableMap = (props) => {
+  const { data, onChangeField } = props;
+  const center = [parseFloat(data.latitude), parseFloat(data.longitude)];
+  const zoom = parseInt(data.zoom);
+  const editRef = useRef();
+  const [map, setMap] = useState();
+  const blockConfig = config.blocks.blocksConfig.leafletMap;
+  const MapControl = React.memo(({ center, zoom }) => {
+    const map = useMap();
+    if (!center[0] || !center[1] || !zoom) {
+      return null;
+    }
+    map.flyTo(center, zoom);
+    return null;
+  });
+
+  const markersIcons = config.blocks.blocksConfig.leafletMap.markerIcons;
+  const icon = markersIcons['default'].icon;
+  const iconHtml = `
+    <svg
+      xmlns="${icon.attributes && icon.attributes.xmlns}"
+      viewBox="${icon.attributes && icon.attributes.viewBox}"
+    >
+      ${icon.content}
+    </svg>`;
+
+  const leafletIcon = L.divIcon({
+    html: iconHtml,
+    iconSize: [40, 40],
+    iconAnchor: [20, 40],
+  });
+
+  const addMarker = (latlng) => {
+    const markers = data?.markers ? [...data.markers] : [];
+    markers.push({
+      '@id': uuid(),
+      title: 'New Marker',
+      latitude: latlng.lat,
+      longitude: latlng.lng,
+      icon: 'default',
+    });
+    onChangeField('markers', markers);
+  };
+
+  const LocationMarker = () => {
+    const [position, setPosition] = useState(null);
+    const map = useMapEvents({
+      click(e) {
+        setPosition(e.latlng);
+        map.flyTo(e.latlng, map.getZoom());
+        addMarker(e.latlng);
+      },
+    });
+
+    return position === null ? null : (
+      <LeafletMarker position={position} icon={leafletIcon}>
+        <Popup>You are here</Popup>
+      </LeafletMarker>
+    );
+  };
+
+  return (
+    <ReactLeafletEditable ref={editRef} map={map}>
+      <MapContainer
+        editable={true}
+        zoom={zoom}
+        center={center}
+        whenCreated={setMap}
+        style={{ height: '100%' }}
+      >
+        <MapControl center={center} zoom={zoom} />
+
+        <LocationMarker />
+        <RenderMarkers data={data} />
+        <TileLayer
+          url={blockConfig.tilesLayerUrl}
+          attribution={blockConfig.tilesLayerAttribution}
+        />
+      </MapContainer>
+    </ReactLeafletEditable>
+  );
+};
+
+export { EditableMap };

--- a/src/Blocks/LeafletMap/Map.jsx
+++ b/src/Blocks/LeafletMap/Map.jsx
@@ -2,15 +2,16 @@ import React from 'react';
 
 import config from '@plone/volto/registry';
 import { MapContainer, TileLayer, useMap } from '@monsonjeremy/react-leaflet';
-
-import Marker from './Marker';
+import 'leaflet-editable';
+import RenderMarkers from './RenderMarkers';
 import '../../style/leaflet.less';
+import { EditableMap } from './EditableMap';
 
 const Map = (props) => {
-  const { data } = props;
+  const { data, editMode, onChangeField } = props;
   const center = [parseFloat(data.latitude), parseFloat(data.longitude)];
   const zoom = parseInt(data.zoom);
-  const blockConfig = config.blocks.blocksConfig.leafletMap
+  const blockConfig = config.blocks.blocksConfig.leafletMap;
 
   const MapControl = React.memo(({ center, zoom }) => {
     const map = useMap();
@@ -23,16 +24,19 @@ const Map = (props) => {
 
   return (
     <div className="leaflet-wrapper" style={{ height: data.height }}>
-      <MapContainer center={center} zoom={zoom} style={{ height: '100%' }}>
-        <MapControl center={center} zoom={zoom} />
-        <TileLayer
-          url={blockConfig.tilesLayerUrl}
-          attribution={blockConfig.tilesLayerAttribution}
-        />
-        {data.markers?.map((marker) => (
-          <Marker key={marker['@id']} marker={marker} />
-        ))}
-      </MapContainer>
+      {editMode ? (
+        <EditableMap data={data} onChangeField={onChangeField} />
+      ) : (
+        <MapContainer center={center} zoom={zoom} style={{ height: '100%' }}>
+          <MapControl center={center} zoom={zoom} />
+          <TileLayer
+            url={blockConfig.tilesLayerUrl}
+            attribution={blockConfig.tilesLayerAttribution}
+          />
+
+          <RenderMarkers data={data} />
+        </MapContainer>
+      )}
     </div>
   );
 };

--- a/src/Blocks/LeafletMap/Marker.jsx
+++ b/src/Blocks/LeafletMap/Marker.jsx
@@ -4,7 +4,7 @@ import L from 'leaflet';
 import { Marker as LeafletMarker } from '@monsonjeremy/react-leaflet';
 
 const Marker = (props) => {
-  const { marker } = props;
+  const { marker, children } = props;
   const { icon: iconId, latitude, longitude } = marker;
 
   const markersIcons = config.blocks.blocksConfig.leafletMap.markerIcons;
@@ -29,7 +29,9 @@ const Marker = (props) => {
 
   if (latitude && longitude) {
     return (
-      <LeafletMarker icon={leafletIcon} position={[latitude, longitude]} />
+      <LeafletMarker icon={leafletIcon} position={[latitude, longitude]}>
+        {children}
+      </LeafletMarker>
     );
   }
   return null;

--- a/src/Blocks/LeafletMap/RenderMarkers.jsx
+++ b/src/Blocks/LeafletMap/RenderMarkers.jsx
@@ -1,0 +1,14 @@
+import Marker from './Marker';
+import { Popup } from '@monsonjeremy/react-leaflet';
+
+const RenderMarkers = (props) => {
+  const { data } = props;
+
+  return data.markers?.map((marker) => (
+    <Marker key={marker['@id']} marker={marker}>
+      <Popup>{marker.title}</Popup>
+    </Marker>
+  ));
+};
+
+export default RenderMarkers;


### PR DESCRIPTION
One of the features I miss in this addon is the possibility to add markers through the map. 

Adding [react-leaflet-editable](https://www.npmjs.com/package/react-leaflet-editable) and [leaflet-editable](https://www.npmjs.com/package/leaflet-editable) as a dependency and some changes here and there, it's a pretty straightforward implementation.

I have also added a Popup to the markers, this way we can easily show their title when clicking on them.