### PR TITLE
add a configurable list of layers in the block configuration form

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package adds a new map block based on [Leaflet](https://github.com/Leaflet/
 - Add some markers on the map
 
 ## Profiles
-In your `package.json` file: 
+In your `package.json` file:
 ### Minimal
 ```JSON
 "addons": [
@@ -30,11 +30,30 @@ This will install the minimum config for this addon.
 ```
 This will install the minimum config + some preset markers.
 
+## Custom tiles
+
+The block provides several base tile layers and offers a dropdown to select one to be used in your map.
+
+Moreover, the list of available base tile layers can be configured by the integrator, modifying the corresponding
+configuration setting in your Volto project:
+
+```JSON
+config.blocksConfig.leafletMap.tileLayers = [
+  {
+    id: 'some-unique-id',
+    name: 'Name to be shown in the drop down',
+    url: 'https://url.of.the.tile.layer.service/{z}/{x}/{y}.png',
+    attribution: 'Attribution string'
+  }
+]
+
+
+```
+
 ## Roadmap
 
 - Add Cypress tests
 - Better coordinates widget (it's a bit clunky for now)
-- Change map tiles source on the edit view
 - More preset icons
 - Better icon select widget (it's fine for a few icons but if you have hundred of them it's a mess)
 - Draw path on the map (maybe, it seems difficult)
@@ -42,9 +61,9 @@ This will install the minimum config + some preset markers.
 
 ## Known issues
 ### Improper dependency for [React Leaflet](https://github.com/PaulLeCam/react-leaflet)
- 
-Currently, react-leaflet v3.x doesn't support Webpack v4, so we depend on [@monsonjeremy/react-leaflet](https://www.npmjs.com/package/@monsonjeremy/react-leaflet) 
-which is compatible with Webpack v4. 
+
+Currently, react-leaflet v3.x doesn't support Webpack v4, so we depend on [@monsonjeremy/react-leaflet](https://www.npmjs.com/package/@monsonjeremy/react-leaflet)
+which is compatible with Webpack v4.
 
 See here : https://github.com/PaulLeCam/react-leaflet/pull/885
 

--- a/src/Blocks/LeafletMap/Map.jsx
+++ b/src/Blocks/LeafletMap/Map.jsx
@@ -10,7 +10,7 @@ const Map = (props) => {
   const { data } = props;
   const center = [parseFloat(data.latitude), parseFloat(data.longitude)];
   const zoom = parseInt(data.zoom);
-  const blockConfig = config.blocks.blocksConfig.leafletMap
+  const blockConfig = config.blocks.blocksConfig.leafletMap;
 
   const MapControl = React.memo(({ center, zoom }) => {
     const map = useMap();
@@ -21,13 +21,21 @@ const Map = (props) => {
     return null;
   });
 
+  const selectedLayer = blockConfig.tileLayers.filter(
+    (item) => item.id === data.tilesLayer,
+  )[0];
+
   return (
     <div className="leaflet-wrapper" style={{ height: data.height }}>
       <MapContainer center={center} zoom={zoom} style={{ height: '100%' }}>
         <MapControl center={center} zoom={zoom} />
         <TileLayer
-          url={blockConfig.tilesLayerUrl}
-          attribution={blockConfig.tilesLayerAttribution}
+          url={selectedLayer ? selectedLayer.url : blockConfig.tilesLayerUrl}
+          attribution={
+            selectedLayer
+              ? selectedLayer.attribution
+              : blockConfig.tilesLayerAttribution
+          }
         />
         {data.markers?.map((marker) => (
           <Marker key={marker['@id']} marker={marker} />

--- a/src/Blocks/LeafletMap/schema.js
+++ b/src/Blocks/LeafletMap/schema.js
@@ -1,4 +1,5 @@
 import { defineMessages } from 'react-intl';
+import config from '@plone/volto/registry';
 
 export const ILeafletMarkerSchema = (intl) => ({
   title: intl.formatMessage(messages.marker),
@@ -38,7 +39,7 @@ export const ILeafletMapSchema = (intl) => ({
     {
       id: 'default',
       title: 'Default',
-      fields: ['latitude', 'longitude', 'zoom'],
+      fields: ['latitude', 'longitude', 'zoom', 'tilesLayer'],
     },
     {
       id: 'content',
@@ -73,6 +74,12 @@ export const ILeafletMapSchema = (intl) => ({
       initialValue: 8,
       maximum: 18,
       minimum: 0,
+    },
+    tilesLayer: {
+      title: intl.formatMessage(messages.tilesLayer),
+      choices: config.blocks.blocksConfig.leafletMap.tileLayers.map((item) => {
+        return [item.id, item.name];
+      }),
     },
     height: {
       title: intl.formatMessage(messages.height),
@@ -131,5 +138,9 @@ const messages = defineMessages({
   style: {
     id: 'Style',
     defaultMessage: 'Style',
+  },
+  tilesLayer: {
+    id: 'Tiles Layer',
+    defaultMessage: 'Tiles layer',
   },
 });

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,39 @@ const leafletMapConfig = {
       iconAnchor: [20, 40],
     },
   },
-  tilesLayerUrl: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-  tilesLayerAttribution: "&copy; <a href=\"http://osm.org/copyright\">OpenStreetMap</a> contributors"
+  tilesLayerUrl: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  tilesLayerAttribution:
+    '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+  tileLayers: [
+    {
+      id: 'osm',
+      name: 'OpenStreetMap',
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      attribution:
+        '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+    },
+    {
+      id: 'osmfr',
+      name: 'OpenStreetMap-Fr',
+      url: 'https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png',
+      attribution:
+        'map data \u00a9 <a href="http://osm.org/copyright">OpenStreetMap</a> contributors under ODbL ',
+    },
+    {
+      id: 'osmde',
+      name: 'OpenStreetMap-De',
+      url: 'https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png',
+      attribution:
+        'map data \u00a9 <a href="http://osm.org/copyright">OpenStreetMap</a> contributors under ODbL ',
+    },
+    {
+      id: 'opentopomap',
+      name: 'OSM OpenTopoMap',
+      url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+      attribution:
+        'Kartendaten: \u00a9 <a href="http://osm.org/copyright">OpenStreetMap</a> Mitwirkende, <a href="http://viewfinderpanoramas.org/">SRTM</a> | map style: \u00a9 <a href=""https://opentopomap.org/">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+    },
+  ],
 };
 
 export function minimal(config) {


### PR DESCRIPTION
With these changes it's easier to select a custom basemap for the block. 

I have made the list of available maps configurable and selectable in the block itself.

As a backwards compatibility feature, I keep the default base tile layer url that was being used previously.

Now the user of the block can select between the configured list of base maps the one that she wants to use.